### PR TITLE
Let Bild Status Badge point to the actions when clicking on it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Jooq-Modelator
 ==============
 
-[![GitHub license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/ayedo/jooq-modelator/master/LICENSE) [![Build Status](https://github.com/ayedo/jooq-modelator/workflows/Check/badge.svg)](https://github.com/ayedo/jooq-modelator/actions)
+[![GitHub license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/ayedo/jooq-modelator/master/LICENSE) [![Github Workflow Status](https://github.com/ayedo/jooq-modelator/workflows/Check/badge.svg)](https://github.com/ayedo/jooq-modelator/actions)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Jooq-Modelator
 ==============
 
-[![GitHub license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/ayedo/jooq-modelator/master/LICENSE) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ayedo/jooq-modelator/Check)
+[![GitHub license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/ayedo/jooq-modelator/master/LICENSE) [![Build Status](https://github.com/ayedo/jooq-modelator/workflows/Check/badge.svg)](https://github.com/ayedo/jooq-modelator/actions)
 
 ## Overview
 


### PR DESCRIPTION
Hi @ayedo 

Thanks for merging my PR and releasing a new version. That's perfect.

I saw that my approach to have the build status badge point to the correct place did not work and you fixed it. I only now realised that I had renamed the github actions script and did not adjust the badge.

This PR would allow the user to jump directly to the respective action page. Feel free to merge or close the PR.