### PR TITLE
update failsafe library to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile gradleApi()
 
     compile('org.jetbrains.kotlin:kotlin-stdlib-jdk8')
-    compile('net.jodah:failsafe:1.1.1')
+    compile('net.jodah:failsafe:2.4.0')
     compile('com.spotify:docker-client:8.16.0')
     compile('org.flywaydb:flyway-core:6.4.4')
     compile('org.liquibase:liquibase-core:3.10.0') {


### PR DESCRIPTION
We ran into an incompatibility with another Gradle plugin that uses a newer version of `net.jodah:failsafe` causing the `generateJooqMetamodel` to fail. I tracked it down to a change in the signature of the `withDelay` and `withMaxDuration` methods.